### PR TITLE
No longer need to provide the preview media type

### DIFF
--- a/scripts/modules/github-admin-toolkit.py
+++ b/scripts/modules/github-admin-toolkit.py
@@ -325,7 +325,7 @@ def getRecentTrafficForRepo(repo):
     
     debugMsg('Entered getRecentTrafficForRepo()')
     
-    global acceptHeaderSpiderman
+    global acceptHeader
     
     # Let's keep track of the summary
     dictReferrers = {}
@@ -336,7 +336,7 @@ def getRecentTrafficForRepo(repo):
     # +----------------------------+
     # | List referrers             |
     # +----------------------------+
-    headers = {'Accept' : acceptHeaderSpiderman, 'Authorization' : getAuth()}
+    headers = {'Accept' : acceptHeader, 'Authorization' : getAuth()}
     scheme, code, response = getHTTPResponse(headers, '/repos/' + getOwner() + '/' + repo + '/traffic/popular/referrers')
 
     # Build the output
@@ -358,7 +358,7 @@ def getRecentTrafficForRepo(repo):
     # +----------------------------+
     # | List paths                 |
     # +----------------------------+
-    headers = {'Accept' : acceptHeaderSpiderman, 'Authorization' : getAuth()}
+    headers = {'Accept' : acceptHeader, 'Authorization' : getAuth()}
     scheme, code, response = getHTTPResponse(headers, '/repos/' + getOwner() + '/' + repo + '/traffic/popular/paths')
     
     # Build the output
@@ -380,7 +380,7 @@ def getRecentTrafficForRepo(repo):
     # +----------------------------+
     # | List views                 |
     # +----------------------------+
-    headers = {'Accept' : acceptHeaderSpiderman, 'Authorization' : getAuth()}
+    headers = {'Accept' : acceptHeader, 'Authorization' : getAuth()}
     scheme, code, response = getHTTPResponse(headers, '/repos/' + getOwner() + '/' + repo + '/traffic/views')
     
     # Build the output
@@ -398,7 +398,7 @@ def getRecentTrafficForRepo(repo):
     # +----------------------------+
     # | List clones                 |
     # +----------------------------+
-    headers = {'Accept' : acceptHeaderSpiderman, 'Authorization' : getAuth()}
+    headers = {'Accept' : acceptHeader, 'Authorization' : getAuth()}
     scheme, code, response = getHTTPResponse(headers, '/repos/' + getOwner() + '/' + repo + '/traffic/clones')
     
     # Build the output


### PR DESCRIPTION
As a result of [this announcement](https://developer.github.com/changes/2016-12-28-end-traffic-api-preview/), we no longer need to provide the _preview_ media type for the **Accept** header :+1: